### PR TITLE
Use wildcard product IDs to handle any Yubikey device

### DIFF
--- a/com.podtynnyi.yubikeylockd.plist
+++ b/com.podtynnyi.yubikeylockd.plist
@@ -15,7 +15,7 @@
         <key>com.apple.device-attach</key>
         <dict>
             <key>idProduct</key>
-            <integer>278</integer>
+            <string>*</string>
             <key>idVendor</key>
             <integer>4176</integer>
             <key>IOProviderClass</key>


### PR DESCRIPTION
I have multiple Yubikey device types and it seems tedious to
have to maintain a list of product IDs since they will 
change not only as new products are released but for each
major configuration mode enabled on the device.

This does not appear to be well documented on Apple’s site
but the Mac sysadmin community has exactly the documentation
I needed – see e.g.:

http://docs.macsysadmin.se/2014/pdf/Launchd_-_At_your_service.pdf