### PR TITLE
Lock OSX Keychain when Yubikey is removed

### DIFF
--- a/yubikeylockd.c
+++ b/yubikeylockd.c
@@ -40,6 +40,10 @@ void DeviceNotification( void *		refCon,
         // Run lock via idle
         //
         printf("Yubikey removed. Lock the screen.\n");
+        
+        // Lock the keychain too
+        system("/usr/bin/security lock-keychain");
+        
         io_registry_entry_t reg = IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/IOResources/IODisplayWrangler");
         if (reg) {
             IORegistryEntrySetCFProperty(reg, CFSTR("IORequestIdle"), kCFBooleanTrue);


### PR DESCRIPTION
You should lock the Keychain too when the Yubikey is removed. Try this fix.